### PR TITLE
Fix use of cache_filesystem

### DIFF
--- a/R/gbcbd_utils.R
+++ b/R/gbcbd_utils.R
@@ -48,7 +48,7 @@ gbcbd_get_JSON_fct <- function(use.memoise = TRUE,
 
   if (use.memoise) {
     fct_JSON <- memoise::memoise(f = jsonlite::fromJSON,
-                                 cache = cache.path)
+                                 cache = memoise::cache_filesystem(cache.path))
   } else {
     fct_JSON <- jsonlite::fromJSON
   }


### PR DESCRIPTION
We are planning to release a new version of the memoise package in a few weeks, and in our reverse dependency checks, we found that GetBCBData had a test failure.

The failure is due to a bug in `gbcbd_get_JSON_fct()`, which I've fixed in this pull request. The call to `memoise()` passes a path string as the `cache` parameter. In the current CRAN version of memoise, this will not throw an error at that point, but it will throw an error of the memoized function is ever called. In the development version of [memoise](https://github.com/r-lib/memoise), this throws an error immediately, and so this example fails:
https://github.com/msperlin/GetBCBData/blob/c9cf5281affbac581a53a332e3fa030e18c5a74c/R/gbcbd_utils.R#L45

Please merge this and release a new version to CRAN soon; we plan to release memoise by Jan 25, and reverse dependencies like GetBCBData will need to be fixed on CRAN by then. Thanks!